### PR TITLE
Add nix compilation

### DIFF
--- a/CustomSundials/default.nix
+++ b/CustomSundials/default.nix
@@ -1,0 +1,67 @@
+{ stdenv
+, lib
+, cmake
+, fetchFromGitHub
+, llvmPackages
+, python
+, liblapack
+, gfortran
+, suitesparse
+, lapackSupport ? true }:
+
+let liblapackShared = liblapack.override {
+  shared = true;
+};
+
+in stdenv.mkDerivation rec {
+  pname = "sundials";
+  version = "5.3.0";
+
+  buildInputs = lib.optionals (lapackSupport) [ gfortran ];
+  nativeBuildInputs =  [ cmake ];
+
+  src = fetchFromGitHub {
+    owner = "novadiscovery";
+    repo = "sundials";
+    rev = "f914d2c7cb4c8084a3e64bf19cb12a55e134f18e";
+    sha256 = "sha256-hG8yDifuvo3fM4z8HU/7T4CiqycPgNmcvDjdl2Imxtc=";
+  };
+
+  cmakeFlags = [
+    "-DEXAMPLES_INSTALL_PATH=${placeholder "out"}/share/examples"
+  ] ++ lib.optionals (lapackSupport) [
+
+    "-DSUNDIALS_INDEX_SIZE=64"
+
+    "-DBUILD_SHARED_LIBS=OFF"
+    "-DBUILD_STATIC_LIBS=ON"
+
+    "-DBUILD_CVODE=ON"
+    "-DBUILD_CVODES=OFF"
+    "-DBUILD_IDA=OFF"
+    "-DBUILD_IDAS=OFF"
+    "-DBUILD_ARKODE=ON"
+    "-DBUILD_KINSOL=OFF"
+    "-DBUILD_TESTING=ON"
+    "-DEXAMPLES_ENABLE_C=OFF"
+    "-DEXAMPLES_ENABLE_CXX=OFF"
+    "-DEXAMPLES_INSTALL=OFF"
+
+    "-DKLU_ENABLE=ON"
+    "-DKLU_INCLUDE_DIR=${suitesparse.dev}/include"
+    "-DKLU_LIBRARY_DIR=${suitesparse}/lib"
+
+    "-DLAPACK_ENABLE=ON"
+    "-DLAPACK_LIBRARIES=${liblapackShared}/lib/liblapack${stdenv.hostPlatform.extensions.sharedLibrary};${liblapackShared}/lib/libblas${stdenv.hostPlatform.extensions.sharedLibrary}"
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Suite of nonlinear differential/algebraic equation solvers";
+    homepage    = https://computation.llnl.gov/projects/sundials;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ flokli idontgetoutmuch ];
+    license     = licenses.bsd3;
+  };
+}

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,27 @@
+let
+
+  sundialsOverlay = self: super:
+    {
+      sundials1 = self.callPackage ./CustomSundials { };
+    };
+
+  nixpkgs = fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/22.05.tar.gz";
+    sha256 = "sha256:0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik";
+  };
+
+in
+
+{ pkgs ? import nixpkgs { overlays = [ sundialsOverlay ]; } }:
+
+let
+  cabal2nixPkg = pkgs.haskellPackages.callCabal2nix "hmatrix-sundials" ./. {
+    klu = pkgs.suitesparse;
+    suitesparseconfig = pkgs.suitesparse;
+    sundials_arkode = pkgs.sundials1;
+    sundials_cvode = pkgs.sundials1;
+    sundials_sunlinsolklu = pkgs.sundials1;
+    sundials_sunmatrixsparse = pkgs.sundials1;
+  };
+in
+pkgs.haskellPackages.callPackage cabal2nixPkg { }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,44 @@
+let
+
+  sundialsOverlay = self: super:
+    {
+      sundials1 = self.callPackage ./CustomSundials { };
+    };
+
+  nixpkgs = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/22.05.tar.gz";
+    sha256 = "sha256:0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik";
+  };
+
+in
+
+{ pkgs ? import nixpkgs { overlays = [ sundialsOverlay ]; }
+, compiler ? "default"
+, doBenchmark ? false
+}:
+
+let
+
+  haskellPackages =
+    if compiler == "default"
+    then pkgs.haskellPackages
+    else pkgs.haskell.packages.${compiler};
+
+  variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
+
+  drv = variant (pkgs.haskellPackages.callCabal2nix "hmatrix-sundials" ./. {
+    klu = pkgs.suitesparse;
+    suitesparseconfig = pkgs.suitesparse;
+    sundials_arkode = pkgs.sundials1;
+    sundials_cvode = pkgs.sundials1;
+    sundials_sunlinsolklu = pkgs.sundials1;
+    sundials_sunmatrixsparse = pkgs.sundials1;
+  });
+
+  envWithTools = drv.env.overrideAttrs (old: {
+    nativeBuildInputs = (old.nativeBuildInputs or []) ++ [ haskellPackages.cabal-install ];
+  });
+
+in
+
+if pkgs.lib.inNixShell then envWithTools else drv


### PR DESCRIPTION
Copied from https://github.com/haskell-numerics/hmatrix-sundials/tree/8333309c82b737247d3c14e66ae245febb1a6ab0 with a few changes:
- pin to nixpkgs 22.05 with the necessary fixes
- use sundials from https://github.com/novadiscovery/sundials/tree/f914d2c7cb4c8084a3e64bf19cb12a55e134f18e
- use default.nix from shell.nix to avoid some code duplication