### PR TITLE
fix: Exception in haskell condition gracefully shutdown solver

### DIFF
--- a/tests/golden/ARKode/ARKMethod FEHLBERG_6_4_5/Exception_in_condition.json
+++ b/tests/golden/ARKode/ARKMethod FEHLBERG_6_4_5/Exception_in_condition.json
@@ -1,0 +1,20 @@
+{
+    "Left": {
+        "errorCode": 45,
+        "errorEstimates": [
+            0,
+            -1
+        ],
+        "partialResults": [
+            [
+                0,
+                0,
+                1
+            ]
+        ],
+        "varWeights": [
+            1000000000000,
+            9.900990099009901e9
+        ]
+    }
+}

--- a/tests/golden/ARKode/ARKMethod SDIRK_5_3_4/Exception_in_condition.json
+++ b/tests/golden/ARKode/ARKMethod SDIRK_5_3_4/Exception_in_condition.json
@@ -1,0 +1,20 @@
+{
+    "Left": {
+        "errorCode": 45,
+        "errorEstimates": [
+            0,
+            -1
+        ],
+        "partialResults": [
+            [
+                0,
+                0,
+                1
+            ]
+        ],
+        "varWeights": [
+            1000000000000,
+            9.900990099009901e9
+        ]
+    }
+}

--- a/tests/golden/ARKode/ARKMethod TRBDF2_3_3_2/Exception_in_condition.json
+++ b/tests/golden/ARKode/ARKMethod TRBDF2_3_3_2/Exception_in_condition.json
@@ -1,0 +1,20 @@
+{
+    "Left": {
+        "errorCode": 45,
+        "errorEstimates": [
+            0,
+            -1
+        ],
+        "partialResults": [
+            [
+                0,
+                0,
+                1
+            ]
+        ],
+        "varWeights": [
+            1000000000000,
+            9.900990099009901e9
+        ]
+    }
+}

--- a/tests/golden/CVode/CVMethod ADAMS/Exception_in_condition.json
+++ b/tests/golden/CVode/CVMethod ADAMS/Exception_in_condition.json
@@ -1,0 +1,20 @@
+{
+    "Left": {
+        "errorCode": 45,
+        "errorEstimates": [
+            1,
+            0
+        ],
+        "partialResults": [
+            [
+                0,
+                0,
+                1
+            ]
+        ],
+        "varWeights": [
+            1000000000000,
+            9.900990099009901e9
+        ]
+    }
+}

--- a/tests/golden/CVode/CVMethod BDF/Exception_in_condition.json
+++ b/tests/golden/CVode/CVMethod BDF/Exception_in_condition.json
@@ -1,0 +1,20 @@
+{
+    "Left": {
+        "errorCode": 45,
+        "errorEstimates": [
+            1,
+            0
+        ],
+        "partialResults": [
+            [
+                0,
+                0,
+                1
+            ]
+        ],
+        "varWeights": [
+            1000000000000,
+            9.900990099009901e9
+        ]
+    }
+}

--- a/tests/golden/canonical/Exception_in_condition.json
+++ b/tests/golden/canonical/Exception_in_condition.json
@@ -1,0 +1,20 @@
+{
+    "Left": {
+        "errorCode": 45,
+        "errorEstimates": [
+            1,
+            0
+        ],
+        "partialResults": [
+            [
+                0,
+                0,
+                1
+            ]
+        ],
+        "varWeights": [
+            1000000000000,
+            9.900990099009901e9
+        ]
+    }
+}

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -344,6 +344,14 @@ eventTests opts = testGroup "Events"
           }
   , odeGoldenTest True opts "Bounded_sine" $
       runKatipT ?log_env $ solve opts boundedSine
+
+  -- This test checks than an exception in the event condition is correctly
+  -- reported as a solver failure instead of a crash
+  , odeGoldenTest True opts "Exception_in_condition" $
+      runKatipT ?log_env $ solve opts (boundedSine
+        {
+          odeEventConditions = eventConditionsPure (error "I'm an error in condition code")
+        })
   ]
 
 discontinuousRhsTest opts = odeGoldenTest True opts "Discontinuous_derivative" $


### PR DESCRIPTION
In the event of an exception in the Haskell condition code (`EventConditionsHaskell`), the RTS was crashing the program.

Instead, we force the evaluation (i.e. the exception may be hidden in a lazy computation) with `force` / `evaluate`, and return a non 0 value so sundial knows that the solving failed in the root finding function, according to https://sundials.readthedocs.io/en/latest/cvode/Usage/index.html#rootfinding-function