### PR TITLE
feat: cooperative solver stop in case of async exception

### DIFF
--- a/hmatrix-sundials.cabal
+++ b/hmatrix-sundials.cabal
@@ -30,7 +30,9 @@ library
                        text,
                        aeson,
                        katip,
-                       ghc-prim
+                       ghc-prim,
+                       async
+                       
   extra-libraries:     sundials_arkode
                        sundials_cvode
                        sundials_sunmatrixsparse

--- a/src/Numeric/Sundials.hs
+++ b/src/Numeric/Sundials.hs
@@ -75,6 +75,8 @@ import Control.Monad.IO.Class
 import Control.Monad.Cont
 import Control.Exception
 import Control.DeepSeq
+import Foreign (alloca)
+import Control.Concurrent.Async
 
 -- | A supported ODE solving method, either by CVode or ARKode
 data OdeMethod
@@ -134,8 +136,51 @@ solve opts =
       case odeMethod opts of
         CVMethod{} -> CV.solveC
         ARKMethod{} -> ARK.solveC
-  in
-    solveCommon solveC opts
+
+    -- This is the logic to implement interruptible solver.
+    -- The solving can be interrupted at each timepoint, it reads the `ptrStop`
+    -- value to know it needs to. So actually, if the
+    -- solver is stuck in an infinite loop for any reason, there is no
+    -- solution.
+    --
+    -- The idea is as follows:
+    --   - If no exception, the `solveC` function terminates and the `wait` is
+    --   returning the result.
+    --   - If any async exception happen, the `wait` is interrupted`, the
+    --   `exception handler` set `ptrStop to 1` and the exception bubble up to
+    --   the `withAsync` which will wait for completion of the `solveC`
+    --   function. (It will also raise an async exception which will be
+    --   rethrown immediately when leaving the FFI call.
+    --   
+    solveInterruptibleWrapper consts vars env = alloca $ \ptrStop -> do
+     -- Before running the thread, we want to ensure that it won't be stopped
+     -- immediately.
+     poke ptrStop 0
+
+     -- This is the solving action
+     let solvingAction = solveC ptrStop consts vars env
+
+     -- Here for the nasty concurrency logic
+     -- We want to ensure that in case of exception, the call `poke ptrStop 1`
+     -- in order to force the solver to stop.
+     --
+     -- Hence we mask exception the time required to setup correct exception handler
+     mask $ \restore -> do
+       -- Run the computation.
+       a <- async (restore solvingAction)
+
+       -- Now we wait for the computation to be terminated.
+       -- The exception handler is set outside of the wait, so we ensure that
+       -- either we never started the async, OR the exception handler is
+       -- correctly set.
+       --
+       -- The exception handler will first ask kindly the solver to stop by
+       -- setting ptrStop to 1 AND then wait for the stop. Note that we use
+       -- uninterruptibleCancel to force the stop / wait for it in order to
+       -- ensure that no blocked thread will be left over.
+       restore (wait a) `finally` (poke ptrStop 1 >> uninterruptibleCancel a)
+      
+  in solveCommon solveInterruptibleWrapper opts
 
 -- | The common solving logic between ARKode and CVode
 solveCommon

--- a/src/Numeric/Sundials/ARKode.hs
+++ b/src/Numeric/Sundials/ARKode.hs
@@ -263,7 +263,9 @@ solveC ptrStop CConsts{..} CVars{..} log_env =
      // way of a non null value in *ptrSTop
      // The signal is an exception from outside (see the solve function in
      // Numeric/Sundials.hs
-    // Ensure proper memory barrier so that `stopFlag` is not optimised away as constant
+    // Ensure proper memory barrier.
+    // This cannot be simply replaced by if(*ptrStop) because the compiler is free to consider ptrStop as a constant for the complete loop execution.
+    // So instead, we use __atomic_load to force the load
     int stopFlag = 0;
     __atomic_load($(int* ptrStop), &stopFlag, __ATOMIC_SEQ_CST);
 

--- a/src/Numeric/Sundials/ARKode.hs
+++ b/src/Numeric/Sundials/ARKode.hs
@@ -12,6 +12,7 @@ import Foreign.C.Types
 import GHC.Prim
 import GHC.Generics
 import Katip
+import Foreign.Ptr
 
 import Numeric.Sundials.Foreign
 import Numeric.Sundials.Common
@@ -91,11 +92,11 @@ instance IsMethod ARKMethod where
       then Explicit
       else Implicit
 
-solveC :: CConsts -> CVars (VS.MVector RealWorld) -> LogEnv -> IO CInt
-solveC CConsts{..} CVars{..} log_env =
+solveC :: Ptr CInt -> CConsts -> CVars (VS.MVector RealWorld) -> LogEnv -> IO CInt
+solveC ptrStop CConsts{..} CVars{..} log_env =
   let
     report_error = reportErrorWithKatip log_env
-  in
+  in do
   [C.block| int {
   /* general problem variables */
 
@@ -258,6 +259,19 @@ solveC CConsts{..} CVars{..} log_env =
   if (check_flag(&flag, "ARKStepSetTableNum", 1, report_error)) return 26643;
 
   while (1) {
+     // The solver will run until it terminates or receive a signal to stop by the
+     // way of a non null value in *ptrSTop
+     // The signal is an exception from outside (see the solve function in
+     // Numeric/Sundials.hs
+    // Ensure proper memory barrier so that `stopFlag` is not optimised away as constant
+    int stopFlag = 0;
+    __atomic_load($(int* ptrStop), &stopFlag, __ATOMIC_SEQ_CST);
+
+    if(stopFlag)
+    {
+      break;
+    }
+
     double ti = ($vec-ptr:(double *c_sol_time))[input_ind];
     double next_time_event = ($fun:(double (*c_next_time_event)()))();
     if (next_time_event < t_start) {

--- a/src/Numeric/Sundials/CVode.hs
+++ b/src/Numeric/Sundials/CVode.hs
@@ -203,7 +203,9 @@ solveC ptrStop CConsts{..} CVars{..} log_env =
      // way of a non null value in *ptrSTop
      // The signal is an exception from outside (see the solve function in
      // Numeric/Sundials.hs
-    // Ensure proper memory barrier so that `stopFlag` is not optimised away as constant
+    // Ensure proper memory barrier.
+    // This cannot be simply replaced by if(*ptrStop) because the compiler is free to consider ptrStop as a constant for the complete loop execution.
+    // So instead, we use __atomic_load to force the load
     int stopFlag = 0;
     __atomic_load($(int* ptrStop), &stopFlag, __ATOMIC_SEQ_CST);
 


### PR DESCRIPTION
If an async exception (such as a timeout, are thread cancel) was happening when the solver was the inline-c block, nothing was happening and the exception was ignored until the inline-c block terminates, which could take a long time if the solver was working on an hard task.

This commit improves the situation:

- In the haskell thread, we wait for exception. If any happen, we set `*ptrStop = 1`. This value is visible from the FFI call.
- In the solver (i.e. the FFI call), we test `*ptrStop` after each timepoints and stop the solver if required, after the necessary cleanups.

A few implementation details:
- if the solver is stopped by an exception, the `FFI` call will be terminated thanks to the `ptrStop` logic AND the exception will be raised again once terminated. So it is not possible to stop the solver AND use the result by mistake.
- The `ptrStop` cannot just be read at each loop without proper synchronisation. In practice, the loop is complex enough so the compiler had really few chances to not generate the read for `*ptrStop`, but this is not guaranted. Using the `__atomic_load` ensures that proper barrier for compiler and CPU are set.