### PR TITLE
feat: safe exception in event handler

### DIFF
--- a/src/Numeric/Sundials/ARKode.hs
+++ b/src/Numeric/Sundials/ARKode.hs
@@ -367,7 +367,11 @@ solveC ptrStop CConsts{..} CVars{..} log_env =
       int record_events = 0;
       if (n_events_triggered > 0 || time_based_event) {
         /* Update the state with the supplied function */
-        $fun:(int (* c_apply_event) (int, int*, double, N_Vector y, N_Vector z, int*, int*))(n_events_triggered, c_root_info, t, y, y, &stop_solver, &record_events);
+        int error = $fun:(int (* c_apply_event) (int, int*, double, N_Vector y, N_Vector z, int*, int*))(n_events_triggered, c_root_info, t, y, y, &stop_solver, &record_events);
+
+        // If the event handled failed internally, we stop the solving
+        if(error)
+          break;
       }
 
       if (record_events) {

--- a/src/Numeric/Sundials/CVode.hs
+++ b/src/Numeric/Sundials/CVode.hs
@@ -315,7 +315,11 @@ solveC ptrStop CConsts{..} CVars{..} log_env =
       if (n_events_triggered > 0 || time_based_event) {
         /* Update the state with the supplied function */
         DEBUG("Calling the event handler; n_events_triggered = %d; time_based_event = %d", n_events_triggered, time_based_event);
-        $fun:(int (* c_apply_event) (int, int*, double, N_Vector y, N_Vector z, int*, int*))(n_events_triggered, c_root_info, t, y, y, &stop_solver, &record_events);
+        int error = $fun:(int (* c_apply_event) (int, int*, double, N_Vector y, N_Vector z, int*, int*))(n_events_triggered, c_root_info, t, y, y, &stop_solver, &record_events);
+
+        // If the event handled failed internally, we stop the solving
+        if(error)
+          break;
       }
 
       if (record_events) {

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -365,6 +365,17 @@ eventTests opts = testGroup "Events"
         {
           odeRhs = OdeRhsHaskell $ \_ _ -> throwIO ConditionException
         })
+  , testCase "pure exception in event handler" $
+      assertRaises ConditionException $
+        runKatipT ?log_env $ solve opts (boundedSine
+        {
+          odeEventHandler = mkEventHandler
+               [\_ y -> vector [ y ! throw ConditionException, - abs (y ! 1) ]
+               ,\_ y -> vector [ y ! 0, abs (y ! 1) ]
+               ]
+              (V.replicate 2 False)
+              (V.replicate 2 True)
+        })
   ]
 
 data ConditionException = ConditionException


### PR DESCRIPTION
Similarly to https://github.com/novadiscovery/hmatrix-sundials/pull/14, in case of an exception in the event handler, we catch it, stop the solver (using the return value of the event handler) and raise the exception again at call site.