### PR TITLE
feat: safe exception in timespec event

### DIFF
--- a/src/Numeric/Sundials/ARKode.hs
+++ b/src/Numeric/Sundials/ARKode.hs
@@ -276,6 +276,10 @@ solveC ptrStop CConsts{..} CVars{..} log_env =
 
     double ti = ($vec-ptr:(double *c_sol_time))[input_ind];
     double next_time_event = ($fun:(double (*c_next_time_event)()))();
+
+    // Haskell failure in the next time event function
+    if(next_time_event == -1)
+      break;
     if (next_time_event < t_start) {
       size_t msg_size = 1000;
       char *msg = alloca(msg_size);

--- a/src/Numeric/Sundials/CVode.hs
+++ b/src/Numeric/Sundials/CVode.hs
@@ -216,6 +216,11 @@ solveC ptrStop CConsts{..} CVars{..} log_env =
 
     double ti = ($vec-ptr:(double *c_sol_time))[input_ind];
     double next_time_event = ($fun:(double (*c_next_time_event)()))();
+
+    // Haskell failure in the next time event function
+    if(next_time_event == -1)
+      break;
+
     if (next_time_event < t_start) {
       size_t msg_size = 1000;
       char *msg = alloca(msg_size);

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -376,6 +376,18 @@ eventTests opts = testGroup "Events"
               (V.replicate 2 False)
               (V.replicate 2 True)
         })
+  , testCase "pure exception in timespec" $ 
+      assertRaises ConditionException $
+        runKatipT ?log_env $ solve opts (boundedSine
+        {
+          odeTimeBasedEvents = TimeEventSpec $ pure $ throw ConditionException
+        })
+  , testCase "impure exception in timespec" $ 
+      assertRaises ConditionException $
+        runKatipT ?log_env $ solve opts (boundedSine
+        {
+          odeTimeBasedEvents = TimeEventSpec $ throwIO ConditionException
+        })
   ]
 
 data ConditionException = ConditionException


### PR DESCRIPTION
Similarly to https://github.com/novadiscovery/hmatrix-sundials/pull/14, in case of an exception in the timespec handler, we catch it, stop the solver (using the return value of the event handler) and raise the exception again at call site.