### PR TITLE
First tentative for callback progress

### DIFF
--- a/src/Numeric/Sundials.hs
+++ b/src/Numeric/Sundials.hs
@@ -303,6 +303,14 @@ withCConsts ODEOpts{..} OdeProblem{..} = runContT $ do
                                  }
         funptr <- ContT $ bracket (mkOdeRhsC funIO) freeHaskellFunPtr
         return (funptr, nullPtr)
+  let c_ontimepoint idx = do
+        case odeOnTimePoint of
+          Nothing -> pure ()
+          Just fun -> do
+            -- Save the exception (if any)
+            _ <- saveExceptionContext exceptionRef $ do
+              fun idx
+            pure ()
   c_jac <-
     case odeJacobian of
       Nothing   -> return nullFunPtr

--- a/src/Numeric/Sundials/ARKode.hs
+++ b/src/Numeric/Sundials/ARKode.hs
@@ -249,6 +249,7 @@ solveC ptrStop CConsts{..} CVars{..} log_env =
   for (j = 0; j < c_dim; j++) {
     ($vec-ptr:(double *c_output_mat))[0 * (c_dim + 1) + (j + 1)] = NV_Ith_S(y,j);
   }
+  $fun:(void (*c_ontimepoint)(int))(output_ind);
 
   /* Set the Runge-Kutta method */
   if (implicit) {
@@ -335,6 +336,9 @@ solveC ptrStop CConsts{..} CVars{..} log_env =
     for (j = 0; j < c_dim; j++) {
       ($vec-ptr:(double *c_output_mat))[output_ind * (c_dim + 1) + (j + 1)] = NV_Ith_S(y,j);
     }
+
+    $fun:(void (*c_ontimepoint)(int))(output_ind);
+
     output_ind++;
     ($vec-ptr:(int *c_n_rows))[0] = output_ind;
 
@@ -392,6 +396,8 @@ solveC ptrStop CConsts{..} CVars{..} log_env =
         for (j = 0; j < c_dim; j++) {
           ($vec-ptr:(double *c_output_mat))[output_ind * (c_dim + 1) + (j + 1)] = NV_Ith_S(y,j);
         }
+        $fun:(void (*c_ontimepoint)(int))(output_ind);
+
         event_ind++;
         output_ind++;
         ($vec-ptr:(int *c_n_rows))[0] = output_ind;

--- a/src/Numeric/Sundials/CVode.hs
+++ b/src/Numeric/Sundials/CVode.hs
@@ -198,6 +198,8 @@ solveC ptrStop CConsts{..} CVars{..} log_env =
     ($vec-ptr:(double *c_output_mat))[0 * (c_dim + 1) + (j + 1)] = NV_Ith_S(y,j);
   }
 
+  $fun:(void (*c_ontimepoint)(int))(output_ind);
+
   while (1) {
      // The solver will run until it terminates or receive a signal to stop by the
      // way of a non null value in *ptrSTop
@@ -280,6 +282,9 @@ solveC ptrStop CConsts{..} CVars{..} log_env =
     for (j = 0; j < c_dim; j++) {
       ($vec-ptr:(double *c_output_mat))[output_ind * (c_dim + 1) + (j + 1)] = NV_Ith_S(y,j);
     }
+
+    $fun:(void (*c_ontimepoint)(int))(output_ind);
+
     output_ind++;
     ($vec-ptr:(int *c_n_rows))[0] = output_ind;
 
@@ -342,6 +347,8 @@ solveC ptrStop CConsts{..} CVars{..} log_env =
         for (j = 0; j < c_dim; j++) {
           ($vec-ptr:(double *c_output_mat))[output_ind * (c_dim + 1) + (j + 1)] = NV_Ith_S(y,j);
         }
+        $fun:(void (*c_ontimepoint)(int))(output_ind);
+
         event_ind++;
         output_ind++;
         ($vec-ptr:(int *c_n_rows))[0] = output_ind;

--- a/src/Numeric/Sundials/Common.hs
+++ b/src/Numeric/Sundials/Common.hs
@@ -135,6 +135,7 @@ data CConsts = CConsts
   , c_max_err_test_fails :: CInt
   , c_init_step_size_set :: CInt
   , c_init_step_size :: CDouble
+  , c_ontimepoint :: TimePointHandler
   }
 
 data MethodType = Explicit | Implicit
@@ -319,6 +320,12 @@ type EventHandler
     -- If the vector is empty, this is a time-based event.
   -> IO EventHandlerResult
 
+-- | This callback will be called when a timepoint is saved
+-- Maybe in the future we'll use this as a stream provider, but for now it is only used for debuging purpose.
+type TimePointHandler
+  =  CInt -- ^ timepoint index
+  -> IO ()
+
 data OdeProblem = OdeProblem
   { odeEventConditions :: EventConditions
     -- ^ The event conditions
@@ -345,6 +352,7 @@ data OdeProblem = OdeProblem
     -- larger if any events occurred.
   , odeTolerances :: Tolerances
     -- ^ How much error is tolerated in each variable.
+  , odeOnTimePoint :: Maybe TimePointHandler
   }
 
 data Tolerances = Tolerances

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -46,6 +46,8 @@ emptyOdeProblem = OdeProblem
       , odeMaxEvents = 100
       , odeSolTimes = error "emptyOdeProblem: no odeSolTimes provided"
       , odeTolerances = defaultTolerances
+      -- TODO: test this callback
+      , odeOnTimePoint = Nothing
       }
 
 data OdeSolver = OdeSolver


### PR DESCRIPTION
This is a WIP PR in order to add a callback mecanism to sundials solving.

This callback is called each time a timepoint is stored. For now it could be used when the solver produces a result in order to add additionnal metrics to the solver (time, memory usage, ...). But this may be the way to an api where the solver streams the results instead of producing a large matrix. Having a streaming api may open many possibilities:

- Better stop on demand
- Better restart
- Better maragement of the memory size of the output matrix result