### PR TITLE
ida: do not double RecalcIC after event

### DIFF
--- a/src/Numeric/Sundials/Common.hs
+++ b/src/Numeric/Sundials/Common.hs
@@ -339,7 +339,10 @@ type EventHandler
   -> (VS.Vector Double -> IO (VS.Vector Double))
   -- ^ A callback function that the handle can call after handling an event
   -- Depending on the solver, the event handling may have impact on the solver
-  -- values and the event handler may want to see updated values
+  -- values and the event handler may want to see updated values.
+  -- This is the responsability of the event handler to call this callback if
+  -- it had done changes into the state variable which should be taken into
+  -- account before next event.
   -> IO EventHandlerResult
 
 -- | This callback will be called when a timepoint is saved


### PR DESCRIPTION
When the event handler is called, it is responsible to call the callback which would recalculate the initial condition in the event of a change of algebraic equations.

However, we were also doing that a second time unconditionally after an event handling.

This is a performance waste considering that the event handler may had always done that or maybe that the event handler knows that this is not required.

We removed this call and now require that the event handler do the call when required.