### PR TITLE
feat: only reinit when required

### DIFF
--- a/src/Numeric/Sundials.hs
+++ b/src/Numeric/Sundials.hs
@@ -232,7 +232,7 @@ withCConsts ODEOpts{..} OdeProblem{..} = runContT $ do
     c_n_event_specs = fromIntegral $ V.length odeEventDirections
     c_requested_event_direction = V.convert $ V.map directionToInt odeEventDirections
     -- TODO: this is not called from sundial, so the "C" wrapping is not mandatory
-    c_apply_event n_events event_indices_ptr t y_ptr y'_ptr yp_ptr stop_solver_ptr record_event_ptr callback = do
+    c_apply_event n_events event_indices_ptr t y_ptr y'_ptr yp_ptr stop_solver_ptr record_event_ptr do_reinit_ptr callback = do
       event_indices <- vecFromPtr event_indices_ptr (fromIntegral n_events)
       y_vec <- peek y_ptr
       yp_vec <- if yp_ptr == nullPtr then pure $ error "using yp for event in a solver not meant for"
@@ -252,7 +252,9 @@ withCConsts ODEOpts{..} OdeProblem{..} = runContT $ do
           { sunVecN = sunVecN y_vec
           , sunVecVals = VS.unsafeCoerceVector eventNewState
           }
+
         poke stop_solver_ptr . fromIntegral $ fromEnum eventStopSolver
+        poke do_reinit_ptr . fromIntegral $ fromEnum eventDoReinit
         poke record_event_ptr . fromIntegral $ fromEnum eventRecord
     c_max_events = fromIntegral odeMaxEvents
     c_next_time_event = do

--- a/src/Numeric/Sundials/ARKode.hs
+++ b/src/Numeric/Sundials/ARKode.hs
@@ -362,26 +362,27 @@ solveC CConsts {..} CVars {..} log_env =
                                                   go (i + 1) n_events_triggered
                                     go 0 0
 
-                            (record_events, stop_solver) <-
+                            (record_events, stop_solver, do_reinit) <-
                               if (n_events_triggered > 0 || time_based_event)
                                 then do
                                   debug $ printf "Calling the event handler; n_events_triggered = %d; time_based_event = %d" n_events_triggered (bool (0 :: Int) 1 time_based_event)
-                                  (stop_solver, record_events, err) <- liftIO $ alloca $ \stop_solver_ptr -> alloca $ \record_event_ptr -> do
+                                  (stop_solver, record_events, err, do_reinit) <- liftIO $ alloca $ \stop_solver_ptr -> alloca $ \record_event_ptr -> alloca $ \do_reinit_ptr -> do
                                     --       /* Update the state with the supplied function */
                                     err <- VSM.unsafeWith c_root_info $ \c_root_info_ptr -> do
-                                      err <- c_apply_event (fromIntegral n_events_triggered) c_root_info_ptr t (coerce y) (coerce y) nullPtr stop_solver_ptr record_event_ptr (\x -> pure x)
+                                      err <- c_apply_event (fromIntegral n_events_triggered) c_root_info_ptr t (coerce y) (coerce y) nullPtr stop_solver_ptr record_event_ptr do_reinit_ptr (\x -> pure x)
                                       pure err
                                     stop_solver <- peek stop_solver_ptr
                                     record_event <- peek record_event_ptr
-                                    pure (stop_solver, record_event, err)
+                                    do_reinit <- peek do_reinit_ptr
+                                    pure (stop_solver, record_event, err, do_reinit)
 
                                   --       // If the event handled failed internally, we stop the solving
                                   when (err /= 0) $ do
                                     s <- get
                                     liftIO $ throwIO $ Break s
 
-                                  pure (record_events, stop_solver)
-                                else pure (0, 0)
+                                  pure (record_events, stop_solver, do_reinit)
+                                else pure (0, 0, 0)
 
                             if record_events /= 0
                               then do
@@ -428,7 +429,7 @@ solveC CConsts {..} CVars {..} log_env =
                               s <- get
                               liftIO $ throwIO $ Finish s
 
-                            when (n_events_triggered > 0 || time_based_event) $ do
+                            when (do_reinit > 0) $ do
                               debug ("Re-initializing the system")
 
                               -- Before reinit, we get the diagnostics and update the current diagnostics

--- a/src/Numeric/Sundials/CVode.hs
+++ b/src/Numeric/Sundials/CVode.hs
@@ -305,26 +305,28 @@ solveC CConsts {..} CVars {..} log_env =
                                                   go (i + 1) n_events_triggered
                                     go 0 0
 
-                            (record_events, stop_solver) <-
+
+                            (record_events, stop_solver, do_reinit) <-
                               if (n_events_triggered > 0 || time_based_event)
                                 then do
                                   debug $ printf "Calling the event handler; n_events_triggered = %d; time_based_event = %d" n_events_triggered (bool (0 :: Int) 1 time_based_event)
-                                  (stop_solver, record_events, err) <- liftIO $ alloca $ \stop_solver_ptr -> alloca $ \record_event_ptr -> do
+                                  (stop_solver, record_events, err, do_reinit) <- liftIO $ alloca $ \stop_solver_ptr -> alloca $ \record_event_ptr -> alloca $ \do_reinit_ptr -> do
                                     --       /* Update the state with the supplied function */
                                     err <- VSM.unsafeWith c_root_info $ \c_root_info_ptr -> do
-                                      err <- c_apply_event (fromIntegral n_events_triggered) c_root_info_ptr t (coerce y) (coerce y) nullPtr stop_solver_ptr record_event_ptr (\x -> pure x)
+                                      err <- c_apply_event (fromIntegral n_events_triggered) c_root_info_ptr t (coerce y) (coerce y) nullPtr stop_solver_ptr record_event_ptr do_reinit_ptr (\x -> pure x)
                                       pure err
                                     stop_solver <- peek stop_solver_ptr
                                     record_event <- peek record_event_ptr
-                                    pure (stop_solver, record_event, err)
+                                    do_reinit <- peek do_reinit_ptr
+                                    pure (stop_solver, record_event, err, do_reinit)
 
                                   --       // If the event handled failed internally, we stop the solving
                                   when (err /= 0) $ do
                                     s <- get
                                     liftIO $ throwIO $ Break s
 
-                                  pure (record_events, stop_solver)
-                                else pure (0, 0)
+                                  pure (record_events, stop_solver, do_reinit)
+                                else pure (0, 0, 0)
 
                             if record_events /= 0
                               then do
@@ -371,7 +373,7 @@ solveC CConsts {..} CVars {..} log_env =
                               s <- get
                               liftIO $ throwIO $ Finish s
 
-                            when (n_events_triggered > 0 || time_based_event) $ do
+                            when (do_reinit > 0) $ do
                               debug ("Re-initializing the system")
 
                               -- Before reinit, we get the diagnostics and update the current diagnostics

--- a/src/Numeric/Sundials/Common.hs
+++ b/src/Numeric/Sundials/Common.hs
@@ -115,6 +115,7 @@ data CConsts = CConsts
       -> Ptr T.SunVector -- yp
       -> Ptr CInt -- (out) stop the solver?
       -> Ptr CInt -- (out) record the event?
+      -> Ptr CInt -- (out) should we reinit the solver?
       -- | After applying one event, if there are multiples event to apply
       -- (e.g. cascade), you *must* call this calback with the current system
       -- state in order to get an updated system state after solving algebraic constraints
@@ -327,6 +328,13 @@ data EventHandlerResult = EventHandlerResult
     -- solution?
   , eventNewState :: !(VS.Vector Double)
     -- ^ the new state after the event has been applied
+  , eventDoReinit :: !Bool
+  -- ^ Should the solver must be reinitialised after this event
+  -- It should if the event was triggered to handle a discontinuity, or if the event introduced any value (e.g. a discontinuity).
+  -- But it is possible that the handler is called for nothing (time based
+  -- event with complex condition, ...) or that the handler decides that the
+  -- change is relevant for the solver accuracy (for example, if the changed
+  -- value is NOT used in the ode system for example, and only for statistics
   }
 
 type EventHandler

--- a/src/Numeric/Sundials/IDA.hs
+++ b/src/Numeric/Sundials/IDA.hs
@@ -397,7 +397,7 @@ solveC CConsts {..} CVars {..} log_env =
                                                   go (i + 1) n_events_triggered
                                     go 0 0
 
-                            (record_events, stop_solver) <-
+                            (record_events, stop_solver, do_reinit) <-
                               if (n_events_triggered > 0 || time_based_event)
                                 then do
                                   debug $ printf "Calling the event handler; n_events_triggered = %d; time_based_event = %d" n_events_triggered (bool (0 :: Int) 1 time_based_event)
@@ -405,7 +405,7 @@ solveC CConsts {..} CVars {..} log_env =
                                   -- we'll use a small mailbox in order to store the state for the callback
                                   state <- get
                                   ref <- liftIO $ newIORef state
-                                  (stop_solver, record_events, err) <- liftIO $ alloca $ \stop_solver_ptr -> alloca $ \record_event_ptr -> do
+                                  (stop_solver, record_events, err, do_reinit) <- liftIO $ alloca $ \stop_solver_ptr -> alloca $ \record_event_ptr -> alloca $ \do_reinit_ptr -> do
                                     --       /* Update the state with the supplied function */
                                     err <- VSM.unsafeWith c_root_info $ \c_root_info_ptr -> do
                                       let 
@@ -445,11 +445,12 @@ solveC CConsts {..} CVars {..} log_env =
                                           -- Returns it to the caller
                                           VS.generateM (fromIntegral c_dim) (\i -> cNV_Ith_S' y i)
 
-                                      err <- c_apply_event (fromIntegral n_events_triggered) c_root_info_ptr t (coerce y) (coerce y) (coerce yp) stop_solver_ptr record_event_ptr updateOnEvent
+                                      err <- c_apply_event (fromIntegral n_events_triggered) c_root_info_ptr t (coerce y) (coerce y) (coerce yp) stop_solver_ptr record_event_ptr do_reinit_ptr updateOnEvent
                                       pure err
                                     stop_solver <- peek stop_solver_ptr
                                     record_event <- peek record_event_ptr
-                                    pure (stop_solver, record_event, err)
+                                    do_reinit <- peek do_reinit_ptr
+                                    pure (stop_solver, record_event, err, do_reinit)
 
                                   state' <- liftIO $ readIORef ref
                                   put state'
@@ -458,13 +459,14 @@ solveC CConsts {..} CVars {..} log_env =
                                     s <- get
                                     liftIO $ throwIO $ Break s
 
-                                  pure (record_events, stop_solver)
-                                else pure (0, 0)
+                                  pure (record_events, stop_solver, do_reinit)
+                                else pure (0, 0, 0)
 
                             -- After event, we need to reinit the solver to
                             -- smaller timesteps in order to ensure we do not
                             -- miss any discontinuity.
-                            when (n_events_triggered > 0 || time_based_event) $ do
+                            -- TODO: maybe it is incorrect, we have to ensure that IDACalcIC had been called correctly
+                            when (do_reinit > 0) $ do
                               debug ("Re-initializing the system")
                               idaReInit ida_mem t y yp
 

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -205,6 +205,7 @@ mkEventHandler handlers stop_solver_vec record_event_vec t y0 _yp evs callback
         { eventStopSolver = or . map (stop_solver_vec V.!) $ VS.toList evs
         , eventRecord = or . map (record_event_vec V.!) $ VS.toList evs
         , eventNewState = newState'
+        , eventDoReinit = True
         }
 
 mkTimeEvents
@@ -229,6 +230,7 @@ mkTimeEvents time_based_events = do
                       { eventStopSolver
                       , eventRecord
                       , eventNewState = newState'
+                      , eventDoReinit = True
                       }
                   else throwIO $ ErrorCall "Wrong event time"
           else error "mkTimeEvents: got root-based events"


### PR DESCRIPTION
When reinit is False, we do not reinit, allowing for some event to not force the timestep to small size, giving a boost of performance.

This can happen in two context:

a) The event does not do any change (for example, it was removed by some condition) b) The event does a change on a value which have no impact on the ode system, such as a counter. In this context, the solver can continue without being impacted.