### PR TITLE
fix(cvode): update current_t when CV_TOO_CLOSE

### DIFF
--- a/src/Numeric/Sundials/ARKode.hs
+++ b/src/Numeric/Sundials/ARKode.hs
@@ -262,20 +262,27 @@ solveC CConsts {..} CVars {..} log_env =
                           debug $ printf "Main loop iteration: t = %.17g (%a), next time point (ti) = %.17g, next time event = %.17g" (coerce s.t_start :: Double) (coerce ti :: Double) (coerce next_time_event :: Double)
                           (t, flag) <- liftIO $ alloca $ \t_ptr -> do
                             flag <- cARKodeEvolve cvode_mem next_stop_time y t_ptr ARK_NORMAL
-                            t <- peek t_ptr
-                            pure (t, flag)
+
+                            -- When ARK_TOO_CLOSE, the solver do not make any progress
+                            -- and does not update t_ptr
+                            -- See https://github.com/llnl/sundials/issues/840
+                            currentT <-
+                              if flag == ARK_TOO_CLOSE
+                                then pure s.t_start
+                                else peek t_ptr
+                            pure (currentT, flag)
 
                           debug $ printf "ARKode returned %d; now t = %.17g\n" (fromIntegral flag :: Int) (coerce t :: Double)
                           let root_based_event = flag == ARK_ROOT_RETURN
                           let time_based_event = t == next_time_event
-                          (t, _flag) <-
+                          t <-
                             if flag == ARK_TOO_CLOSE && not time_based_event
                               then do
                                 --     /* See Note [CV_TOO_CLOSE]
                                 --        No solving was required; just set the time t manually and continue
                                 --        as if solving succeeded. */
                                 debug $ printf "Got ARK_TOO_CLOSE; no solving was required; proceeding to t = %.17g" (coerce next_stop_time :: Double)
-                                pure (next_stop_time, flag)
+                                pure next_stop_time
                               else do
                                 s <- get
                                 if t == next_stop_time && t == s.t_start && flag == ARK_ROOT_RETURN && not time_based_event
@@ -286,7 +293,7 @@ solveC CConsts {..} CVars {..} log_env =
                                     --        Pretend that the root didn't happen, lest we keep handling it
                                     --        forever. */
                                     debug $ ("Got a root but t == t_start == next_stop_time; pretending it didn't happen" :: String)
-                                    pure (t, ARK_SUCCESS)
+                                    pure t
                                   else do
                                     if not (flag == ARK_TOO_CLOSE && time_based_event) && flag < 0
                                       then do
@@ -306,7 +313,7 @@ solveC CConsts {..} CVars {..} log_env =
 
                                               VSM.write c_local_error_set 0 1
                                             liftIO $ throwIO $ ReturnCode (fromIntegral flag)
-                                      else pure (t, flag)
+                                      else pure t
 
                           --   /* Store the results for Haskell */
                           s <- get

--- a/src/Numeric/Sundials/CVode.hs
+++ b/src/Numeric/Sundials/CVode.hs
@@ -203,20 +203,25 @@ solveC CConsts {..} CVars {..} log_env =
                           debug $ printf "Main loop iteration: t = %.17g (%a), next time point (ti) = %.17g, next time event = %.17g" (coerce s.t_start :: Double) (coerce ti :: Double) (coerce next_time_event :: Double)
                           (t, flag) <- liftIO $ alloca $ \t_ptr -> do
                             flag <- cCVode cvode_mem next_stop_time y t_ptr CV_NORMAL
-                            t <- peek t_ptr
-                            pure (t, flag)
+                            -- When CV_TOO_CLOSE, the solver does not make any progress and does not update t_ptr
+                            -- See https://github.com/llnl/sundials/issues/840
+                            current_t <-
+                              if flag == CV_TOO_CLOSE
+                                then pure $ s.t_start
+                                else peek t_ptr
+                            pure (current_t, flag)
 
                           debug $ printf "CVode returned %d; now t = %.17g\n" (fromIntegral flag :: Int) (coerce t :: Double)
                           let root_based_event = flag == CV_ROOT_RETURN
-                          let time_based_event = t == next_time_event
-                          (t, _flag) <-
+                              time_based_event = t == next_time_event
+                          t <-
                             if flag == CV_TOO_CLOSE && not time_based_event
                               then do
                                 --     /* See Note [CV_TOO_CLOSE]
                                 --        No solving was required; just set the time t manually and continue
                                 --        as if solving succeeded. */
                                 debug $ printf "Got CV_TOO_CLOSE; no solving was required; proceeding to t = %.17g" (coerce next_stop_time :: Double)
-                                pure (next_stop_time, flag)
+                                pure next_stop_time
                               else do
                                 s <- get
                                 if t == next_stop_time && t == s.t_start && flag == CV_ROOT_RETURN && not time_based_event
@@ -227,7 +232,7 @@ solveC CConsts {..} CVars {..} log_env =
                                     --        Pretend that the root didn't happen, lest we keep handling it
                                     --        forever. */
                                     debug $ ("Got a root but t == t_start == next_stop_time; pretending it didn't happen" :: String)
-                                    pure (t, CV_SUCCESS)
+                                    pure t
                                   else do
                                     if not (flag == CV_TOO_CLOSE && time_based_event) && flag < 0
                                       then do
@@ -247,7 +252,7 @@ solveC CConsts {..} CVars {..} log_env =
 
                                               VSM.write c_local_error_set 0 1
                                             liftIO $ throwIO $ ReturnCode (fromIntegral flag)
-                                      else pure (t, flag)
+                                      else pure t
 
                           --   /* Store the results for Haskell */
                           s <- get

--- a/src/Numeric/Sundials/IDA.hs
+++ b/src/Numeric/Sundials/IDA.hs
@@ -292,14 +292,14 @@ solveC CConsts {..} CVars {..} log_env =
                           debug $ printf "IDASolve returned %d; now t = %.17g\n" (fromIntegral flag :: Int) (coerce t :: Double)
                           let root_based_event = flag == IDA_ROOT_RETURN
                           let time_based_event = t == next_time_event
-                          (t, _flag) <-
+                          t <-
                             if flag == IDA_TOO_CLOSE && not time_based_event
                               then do
                                 --     /* See Note [IDA_TOO_CLOSE]
                                 --        No solving was required; just set the time t manually and continue
                                 --        as if solving succeeded. */
                                 debug $ printf "Got IDA_TOO_CLOSE; no solving was required; proceeding to t = %.17g" (coerce next_stop_time :: Double)
-                                pure (next_stop_time, flag)
+                                pure next_stop_time
                               else do
                                 s <- get
                                 if t == next_stop_time && t == s.t_start && flag == IDA_ROOT_RETURN && not time_based_event
@@ -310,7 +310,7 @@ solveC CConsts {..} CVars {..} log_env =
                                     --        Pretend that the root didn't happen, lest we keep handling it
                                     --        forever. */
                                     debug $ ("Got a root but t == t_start == next_stop_time; pretending it didn't happen" :: String)
-                                    pure (t, IDA_SUCCESS)
+                                    pure t
                                   else do
                                     if not (flag == IDA_TOO_CLOSE && time_based_event) && flag < 0
                                       then do
@@ -330,7 +330,7 @@ solveC CConsts {..} CVars {..} log_env =
 
                                               VSM.write c_local_error_set 0 1
                                             liftIO $ throwIO (ReturnCode (fromIntegral flag))
-                                      else pure (t, flag)
+                                      else pure t
 
                           --   /* Store the results for Haskell */
                           s <- get


### PR DESCRIPTION
When CVode returns flag CV_TOO_CLOSE, the current time pointer 't_ptr' is not updated. This becomes a problem in the rare corner case where the next event time te is such that it is so close to the previously requested time that CV_TOO_CLOSE is returned. In such a case, the solver keeps handling the same event over and over, each time recording a new row in the output matrix until it overflows.

This commit also replaces some partial index operations (index and write) with safer counterparts which check the size of the vector and add a call stack